### PR TITLE
Add the `-n` parameter with `create`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,7 +61,7 @@ Use the Serverless Framework open-source CLI to create a new Service using the s
 
 ```sh
 # Create a new Serverless Service/Project
-$ serverless create -u https://github.com/serverless/enterprise-template
+$ serverless create -n my-service -u https://github.com/serverless/enterprise-template
 
 # Change into the newly created directory
 $ cd my-service


### PR DESCRIPTION
Current command is
`serverless create -n my-service -u https://github.com/serverless/enterprise-template` which creates a new directory with the same name as the template, `enterprise-template`; however, the next line shows that the path should be `my-service`.

Adding the `-n` option will create the new project in the `my-service` directory as expected.